### PR TITLE
Fixes to previous unknown issues

### DIFF
--- a/A3_GW_Existence.Altis/Client/Players/fn_playersSyncHandler.sqf
+++ b/A3_GW_Existence.Altis/Client/Players/fn_playersSyncHandler.sqf
@@ -35,8 +35,11 @@ if (!isNull _scriptHandle) exitWith {
 
 // Add handler for syncing
 GW_playerSyncHandler_threadHandle = [] spawn {
-    uiSleep (SYNC_COOLDOWN * 60);
-
-    // Request sync
-    [true] call GW_client_fnc_playerSyncRequest
+    for "_i" from 0 to 1 step 0 do {
+        uiSleep (SYNC_COOLDOWN * 60);
+        // Request sync
+        [true] call GW_client_fnc_playerSyncRequest;
+        // Notify Players
+        [HINT_NORMAL, "Notice", "Your data has automaticlly been synced with our servers."] call GW_client_fnc_notificationsAdd;
+    };
 };

--- a/A3_GW_Existence.Altis/Client/Players/fn_playersSyncHandler.sqf
+++ b/A3_GW_Existence.Altis/Client/Players/fn_playersSyncHandler.sqf
@@ -37,9 +37,11 @@ if (!isNull _scriptHandle) exitWith {
 GW_playerSyncHandler_threadHandle = [] spawn {
     for "_i" from 0 to 1 step 0 do {
         uiSleep (SYNC_COOLDOWN * 60);
+        
         // Request sync
         [true] call GW_client_fnc_playerSyncRequest;
+        
         // Notify Players
-        [HINT_NORMAL, "Notice", "Your data has automaticlly been synced with our servers."] call GW_client_fnc_notificationsAdd;
+        [HINT_NORMAL, "Notice", "Your data has been synced to the database."] call GW_client_fnc_notificationsAdd;
     };
 };

--- a/A3_GW_Existence.Altis/Client/Players/fn_receivePlayerData.sqf
+++ b/A3_GW_Existence.Altis/Client/Players/fn_receivePlayerData.sqf
@@ -149,3 +149,6 @@ GW_player_timeJoined = time;
 
 // Continue initializing
 GW_initPlayer_playerDataReceived = true;
+
+// Sync request
+[false] call GW_client_fnc_playerSyncRequest;


### PR DESCRIPTION
**Fixed:**

- Players data not being synced automatticlly

- A while ago we had an issue with some players loosing their starting money. This was due to the fact that they would.. Join Server > load in & get starting cash > Alt + f4 or something similar bypassing any other abort syncing features... they would then join back and have 0 because the script no longer thinks they are a _newplayer due to them having a database entry. (I think this is what caused it) and because no data was synced they are now on the default 0 cash. Correct me if I'm wrong please my head is hurting.